### PR TITLE
Add root check to run.sh

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ $EUID -ne 0 ]]; then
+    echo "Please run as root" >&2
+    exit 1
+fi
+
 set -e
 
 echo "Updating and upgrading system..."


### PR DESCRIPTION
## Summary
- ensure run.sh only runs with root privileges

## Testing
- `bash -n run.sh`


------
https://chatgpt.com/codex/tasks/task_e_68591f7c7ee88325a7d4d4b0ea5109a7